### PR TITLE
move setLogLevel('info') before cleanup() to enable output

### DIFF
--- a/ofcdemo/simpledemo.py
+++ b/ofcdemo/simpledemo.py
@@ -17,8 +17,8 @@ from mininet.node import RemoteController
 
 if __name__ == '__main__':
 
-    cleanup()
     setLogLevel( 'info' )
+    cleanup()
     net = Mininet( topo=LinearRoadmTopo(txCount=6), autoSetMacs=True,
                    controller=RemoteController )
     disableIPv6( net )


### PR DESCRIPTION
I'm not 100% sure why it doesn't work after cleanup() but
this enables the informational output from Mininet on startup.