### PR TITLE
Fix dataplane OpticalLink boost/amp parameters

### DIFF
--- a/examples/singlelink.py
+++ b/examples/singlelink.py
@@ -55,7 +55,7 @@ class SingleLinkTopo(Topo):
         self.addLink(h2, s2)
         self.addLink(s2, t2, port2=1)
         # WDM link
-        boost = ('boost', {'target_gain':17*dB})
+        boost = ('boost', {'target_gain':3.0*dB})
         amp1 = ('amp1', {'target_gain': 25*.22*dB})
         amp2 = ('amp2', {'target_gain': 25*.22*dB})
         spans = [25*km, amp1, 25*km, amp2]


### PR DESCRIPTION
- allow amp params to be specified as dict *or* list
- for example:
  `boost=('boost1', {'target_gain': 3*dB }),`
  `spans=[25*km, ('amp1', 5*dB), 50*km, ('amp2', 10*dB), ...]`
- also fix OpticalLink docstring
- also reduce bost amp gain to 3dB in singlelink.py
- fixes singlelink.py example signal failure