### PR TITLE
Unidirectional ROADM and links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,27 @@
 Mininet-Optical Examples
 ------------------------
 
+These examples are intended to serve as simple examples of
+how to use the Mininet-Optical emulation API.
+
+*Bidirectional* examples from tutorial:
+
 simplelink.py: simplified single link topology
-
 singlelink.py: single link topology
-
 singleroadm.py: three terminals connected to a single ROADM
+
+Config scripts (using REST API) for above:
+
+config-singlelink.sh: configure {simple,single}link.py
+config-singleroadm.sh: configure singleroadm.py for connectivity
+                       between h1 and h2 (only!)
+
+*Unidirectional* examples:
+
+unilinear1.py: unidirectional linear network with 1-degree ROADMs
+unilinear2.py: unidirectional linear network with 2-degree ROADMs
+uniring.py: unidirectional ring network
+uniroadmchain.py: simple unidirectional ROADM chain(s) for testing
+
+The unidirectional examples currently use the internal control API
+and implement a 'config' CLI command to configure the network.

--- a/examples/singleroadm.py
+++ b/examples/singleroadm.py
@@ -58,7 +58,7 @@ class SingleROADMTopo(Topo):
 
 
 # Debugging: Plot network graph
-def plotNet(net, outfile="singleroadm.png"):
+def plotNet(net, outfile="singleroadm.png", directed=False, layout='circo'):
     "Plot network graph to outfile"
     try:
         import pygraphviz as pgv
@@ -70,8 +70,11 @@ def plotNet(net, outfile="singleroadm.png"):
     colors = {node: color.get(type(node), 'black')
               for node in net.values()}
     nfont = {'fontname': 'helvetica bold', 'penwidth': 3}
-    g = pgv.AGraph(strict=False, directed=False, layout='circo')
-    for node in net.switches:
+    g = pgv.AGraph(strict=False, directed=directed, layout=layout)
+    roadms = [node for node in net.switches if isinstance(node, ROADM)]
+    terms = [node for node in net.switches if isinstance(node, Terminal)]
+    other = [node for node in net.switches if node not in set(roadms+terms)]
+    for node in roadms + terms + other:
         g.add_node(node.name, color=colors[node], **nfont)
     for node in net.hosts:
         g.add_node(node.name, color=colors[node], **nfont, shape='box')

--- a/examples/unilinear1.py
+++ b/examples/unilinear1.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+
+"""
+unilinear1.py: unidirectional linear network with
+               1-degree ROADMs and split Terminal uplink/downlink.
+
+This may be more complicated than what we
+actually want. We are using the base unidirectional
+ROADMs without any interconnection between them,
+in order to avoid the looping bug in the simulator.
+
+This does have the nice feature of minimizing ports at
+the expense of cabling complexity.
+
+An alternate design, simpler in some ways, is to
+interconnect the ROADMs vertically to create real
+2-degree, bi-directional ROADMs.
+"""
+
+from dataplane import ( OpticalLink,
+                        UnidirectionalOpticalLink as ULink,
+                        ROADM, Terminal,
+                        OpticalNet as Mininet,
+                        km, m, dB, dBm )
+
+# from rest import RestServer
+
+from mno.ofcdemo.demolib import OpticalCLI, cleanup
+from mno.examples.singleroadm import plotNet
+
+from mininet.topo import Topo
+from mininet.link import Link
+from mininet.nodelib import LinuxBridge
+from mininet.log import setLogLevel, info
+from mininet.clean import cleanup
+
+from sys import argv
+
+
+class OpticalTopo( Topo ):
+    "Topo with convenience methods for optical networks"
+
+    def wdmLink( self, node1, node2, port1, port2,  **kwargs ):
+        "Convenience function to add a unidirectional link"
+        kwargs.update(cls=ULink)
+        self.addLink( node1, node2, port1=port1, port2=port2, **kwargs )
+
+    def ethLink( self, *args, **kwargs ):
+        "Clarifying alias for addLink"
+        self.addLink( *args, **kwargs, cls=Link )
+
+    def addTerminal( self, *args, **kwargs ):
+        "Convenience alias for addSwitch( ... cls=Terminal )"
+        kwargs.setdefault( 'cls', Terminal )
+        return self.addSwitch( *args, **kwargs )
+
+    def addROADM( self, *args, **kwargs ):
+        "Convenience alias for addSwitch( ... cls=ROADM )"
+        kwargs.setdefault( 'cls', ROADM )
+        return self.addSwitch( *args, **kwargs )
+
+
+
+class UniLinearTopo( OpticalTopo ):
+    """A linear network connected by two strings of
+       unidirectional ROADMs in opposite directions."""
+
+    # ROADM port numbering
+    # Note port 0 seems to conflict with lo0/management port
+    linein  = 1
+    lineout = 2
+    def addport(self, dst): return 2+dst
+    def dropport(self, src): return 2+self.nodecount+src
+
+    # Terminal port numbering (switch uses same ethport)
+    def ethport(self, dst): return dst
+    def uplink(self, dst):  return self.nodecount+dst
+    def downlink(self, src): return 2*self.nodecount+src
+
+    # Network topology
+    def build(self, power=0*dBm, nodecount=3):
+        """Create a unidirectional linear network with the specified
+           operational power and node and transceiver counts"""
+        self.nodecount = nodecount
+        # Add nodes: (host, switch, terminal, ROADMS (east, west))
+        # Note doubled transceivers for unidirectional links!
+        # We also waste a transceiver/port pair for loopback
+        transceivers = tuple((f'tx{ch}', power, 'C')
+                             for ch in range(1, 2*nodecount+1))
+        topts = {'transceivers': transceivers, 'monitor_mode': 'in'}
+        ropts = {} # was: { 'wss_dict': {ch:(7.0,None) for ch in range(1,91)}}
+        sopts = {'cls': LinuxBridge}
+        for i in range(1, nodecount+1):
+            self.addHost(f'h{i}')
+            self.addSwitch(f's{i}', **sopts)
+            self.addTerminal(f't{i}', **topts)
+            self.addROADM(f're{i}', **ropts)
+            self.addROADM(f'rw{i}', **ropts)
+
+        # WAN Optical link parameters
+        boost = ('boost', {'target_gain':17*dB},)
+        aparams = {'target_gain': 50*km*.22, 'monitor_mode':'out'}
+        spans = [50*km, ('amp1', aparams), 50*km, ('amp2', aparams)]
+
+        # Port number helper function aliases
+        linein, lineout = self.linein, self.lineout
+        addport, dropport = self.addport, self.dropport
+        uplink, downlink = self.uplink, self.downlink
+
+        # Add links for each node/POP
+        for node in range(1, nodecount+1):
+            # Unidirectional roadm->roadm optical links
+            lopts = dict(boost=boost, spans=spans)
+            if node < nodecount:
+                self.wdmLink(f're{node}', f're{node+1}', **lopts,
+                             port1=lineout, port2=linein)
+            if node > 1:
+                self.wdmLink(f'rw{node}', f'rw{node-1}', **lopts,
+                             port1=lineout, port2=linein)
+            # Uplinks/downlinks to/from destination nodes
+            for dest in range(1, nodecount+1):
+                if dest == node: continue
+                # One switch<->terminal link per remote node
+                port1 = port2 = self.ethport(dest)
+                self.ethLink(
+                    f's{node}', f't{node}', port1=port1, port2=port2)
+                # Inbound and outbound links
+                outbound = f're{node}' if dest>node else f'rw{node}'
+                inbound = f'rw{node}' if dest>node else f're{node}'
+                self.wdmLink(f't{node}', outbound, spans=[1*m],
+                             port1=uplink(dest), port2=addport(dest))
+                self.wdmLink(inbound, f't{node}', spans=[1*m],
+                             port1=dropport(dest), port2=downlink(dest))
+            # Host-switch links
+            self.ethLink(f'h{node}', f's{node}', port1=1, port2=0)
+
+# Configuration
+
+def config(net, mesh=False, root=1):
+    """Configure linear, unidirectional network
+       mesh: configure full mesh? False
+       root: root node of star topology if not mesh
+       Routing strategy:
+       - We assign a channel to each (src, dst) pair to avoid conflicts.
+       - For the star topology, we root everything at root.
+       - For the full mesh, we route signals eastbound or westbound
+         as needed."""
+
+    info("*** Configuring network...\n")
+
+    # Helper functions
+    topo, nodecount = net.topo, net.topo.nodecount
+    linein, lineout = topo.linein, topo.lineout
+    addport, dropport = topo.addport, topo.dropport
+    uplink, downlink, ethport = topo.uplink, topo.downlink, topo.ethport
+
+    # Allocate Channels:
+    # Each distinct (src, dst) pair gets its own channel,
+    # which eliminates lightpath routing conflicts.
+    channels = {}
+    ch = 1
+    for src in range(1, nodecount+1):
+        for dst in range(1, nodecount+1):
+            if not mesh and src != root and dst != root:
+                continue
+            # We ignore loopback for now
+            if src == dst: continue
+            channels[src, dst] = ch
+            ch += 1
+    print("Channel assignment:")
+    print(channels)
+
+    # Set of all channels for calculating pass channels
+    chset = set(channels.values())
+
+    for i in range(1, nodecount+1):  # local node
+        for j in range(1, nodecount+1):  # remote node
+            if i == j: continue
+            # Star topology is rooted at root
+            if not mesh and i != root and j != root:
+                continue
+            # Configure ROADMS with add/drop/pass channels
+            outbound = net[f're{i}'] if j>i else net[f'rw{i}']
+            inbound = net[f'rw{i}'] if j>i else net[f're{i}']
+            # Channels that are not added/dropped are passed/forwarded
+            addch, dropch = channels[i,j], channels[j,i]
+            print(f'{outbound} add  ch{addch} port {addport(j)}')
+            outbound.connect(addport(j), lineout, [addch])
+            print(f'{inbound} drop ch{dropch} port {dropport(j)}')
+            inbound.connect(linein, dropport(j), [dropch])
+            if 1 < i < nodecount:
+                passchannels = chset - {addch, dropch}
+                print(inbound, 'pass', passchannels)
+                inbound.connect(linein, lineout, passchannels)
+                print(outbound, 'pass', passchannels)
+                outbound.connect(linein, lineout, passchannels)
+            # Configure terminal uplinks and downlinks
+            terminal = net[f't{i}']
+            terminal.connect(
+                ethPort=ethport(j), wdmPort=uplink(j), channel=addch)
+            terminal.connect(
+                wdmPort=downlink(j), ethPort=ethport(j), channel=dropch)
+
+    # Turn on terminals
+    for i in range(1, nodecount+1):
+        net[f't{i}'].turn_on()
+
+
+class CLI( OpticalCLI ):
+    "CLI with config command"
+    def do_config(self, _line):
+        config(self.mn)
+
+
+if __name__ == '__main__':
+
+    cleanup()  # Just in case!
+    setLogLevel('info')
+    if len(argv) == 2 and argv[1] == 'clean': exit(0)
+
+    topo = UniLinearTopo(nodecount=4)
+    net = Mininet(topo=topo, controller=None)
+    # restServer = RestServer(net)
+    net.start()
+    # restServer.start()
+    plotNet(net, outfile='unilinear1.png', directed=True,
+            layout='neato')
+    info( '*** Use config command to configure network \n' )
+    # config(net)
+    CLI(net)
+    # restServer.stop()
+    net.stop()

--- a/examples/unilinear2.py
+++ b/examples/unilinear2.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+"""
+unilinear2.py: unidirectional linear network with
+               2-degree ROADMs and split Terminal uplink/downlink.
+
+This is somewhat simpler than unilinear1.py because
+the middle ROADMs are 2-degree (though the endpoint ROADMs
+are still 1-degre.)
+"""
+
+from dataplane import ( OpticalLink,
+                        UnidirectionalOpticalLink as ULink,
+                        ROADM, Terminal,
+                        OpticalNet as Mininet,
+                        km, m, dB, dBm )
+
+# from rest import RestServer
+
+from mno.ofcdemo.demolib import OpticalCLI, cleanup
+from mno.examples.singleroadm import plotNet
+
+from mininet.topo import Topo
+from mininet.link import Link
+from mininet.nodelib import LinuxBridge
+from mininet.log import setLogLevel, info
+from mininet.clean import cleanup
+
+from sys import argv
+
+
+class OpticalTopo( Topo ):
+    "Topo with convenience methods for optical networks"
+
+    def wdmLink( self, node1, node2, port1, port2,  **kwargs ):
+        "Convenience function to add a unidirectional link"
+        kwargs.update(cls=ULink)
+        self.addLink( node1, node2, port1=port1, port2=port2, **kwargs )
+
+    def ethLink( self, *args, **kwargs ):
+        "Clarifying alias for addLink"
+        self.addLink( *args, **kwargs, cls=Link )
+
+    def addTerminal( self, *args, **kwargs ):
+        "Convenience alias for addSwitch( ... cls=Terminal )"
+        kwargs.setdefault( 'cls', Terminal )
+        return self.addSwitch( *args, **kwargs )
+
+    def addROADM( self, *args, **kwargs ):
+        "Convenience alias for addSwitch( ... cls=ROADM )"
+        kwargs.setdefault( 'cls', ROADM )
+        return self.addSwitch( *args, **kwargs )
+
+
+
+
+class UniLinearTopo2( OpticalTopo ):
+    """A linear network connected by a string of
+       2-degree unidirectional ROADMs."""
+
+    # ROADM port numbering
+    # Eastbound route and Westbound route line ports
+    # (Note port 0 seems to conflict with lo0/management port!)
+    eastin = 1
+    eastout = 2
+    westin = 3
+    westout = 4
+    # Select line in and out from i to j
+    def linein(self, i, j): return self.eastin if i<j else self.westin
+    def lineout(self, i, j): return self.eastout if i<j else self.westout
+    # Local add and drop ports
+    def addport(self, dst): return 4+dst
+    def dropport(self, src): return 4+self.nodecount+src
+
+    # Terminal port numbering (switch uses same ethport)
+    def ethport(self, dst): return dst
+    def uplink(self, dst):  return self.nodecount+dst
+    def downlink(self, src): return 2*self.nodecount+src
+
+    # Network topology
+    def build(self, power=0*dBm, nodecount=3):
+        """Create a unidirectional linear network with the specified
+           operational power and node and transceiver counts"""
+        self.nodecount = nodecount
+        # Add nodes: (host, switch, terminal, ROADMS (east, west))
+        # Note doubled transceivers for unidirectional links!
+        # We also waste a transceiver/port pair for loopback
+        transceivers = tuple((f'tx{ch}', power, 'C')
+                             for ch in range(1, 2*nodecount+1))
+        topts = {'transceivers': transceivers, 'monitor_mode': 'in'}
+        ropts = {}  # was: {'wss_dict': {ch:(7.0,None) for ch in range(1,91)}}
+        sopts = {'cls': LinuxBridge}
+        for i in range(1, nodecount+1):
+            self.addHost(f'h{i}')
+            self.addSwitch(f's{i}', **sopts)
+            self.addTerminal(f't{i}', **topts)
+            self.addROADM(f'r{i}', **ropts)
+
+        # WAN Optical link parameters
+        boost = ('boost', {'target_gain':17*dB},)
+        aparams = {'target_gain': 50*km*.22, 'monitor_mode':'out'}
+        spans = [50*km, ('amp1', aparams), 50*km, ('amp2', aparams)]
+
+        # Aliases for convenience
+        eastin, eastout = self.eastin, self.eastout
+        westin, westout = self.westin, self.westout
+        addport, dropport = self.addport, self.dropport
+        uplink, downlink = self.uplink, self.downlink
+
+        # Add links for each node/POP
+        for node in range(1, nodecount+1):
+            # Eastbound and westbound roadm->roadm links
+            lopts = dict(boost=boost, spans=spans)
+            if node < nodecount:
+                self.wdmLink(f'r{node}', f'r{node+1}', **lopts,
+                             port1=eastout, port2=eastin)
+            if node > 1:
+                self.wdmLink(f'r{node}', f'r{node-1}', **lopts,
+                             port1=westout, port2=westin)
+            # Uplinks/downlinks to/from destination nodes
+            for dest in range(1, nodecount+1):
+                if dest == node: continue
+                # One switch<->terminal link per remote node
+                port1 = port2 = self.ethport(dest)
+                self.ethLink(
+                    f's{node}', f't{node}', port1=port1, port2=port2)
+                # Inbound and outbound links
+                self.wdmLink(f't{node}', f'r{node}', spans=[1*m],
+                             port1=uplink(dest), port2=addport(dest))
+                self.wdmLink(f'r{node}', f't{node}', spans=[1*m],
+                             port1=dropport(dest), port2=downlink(dest))
+            # Host-switch links
+            self.ethLink(f'h{node}', f's{node}', port1=1, port2=0)
+
+# Configuration
+
+def config(net, mesh=False, root=1):
+    """Configure linear, unidirectional network
+       mesh: configure full mesh? False
+       root: root node of star topology if not mesh
+       Routing strategy:
+       - We assign a channel to each (src, dst) pair to avoid conflicts.
+       - For the star topology, we root everything at root.
+       - For the full mesh, we route signals eastbound or westbound
+         as needed."""
+
+    info("*** Configuring network...\n")
+
+    # Helper functions
+    topo, nodecount = net.topo, net.topo.nodecount
+    eastin, eastout = topo.eastin, topo.eastout
+    westin, westout = topo.westin, topo.westout
+    linein, lineout = topo.linein, topo.lineout
+    addport, dropport = topo.addport, topo.dropport
+    uplink, downlink, ethport = topo.uplink, topo.downlink, topo.ethport
+
+    # Allocate Channels:
+    # Each distinct (src, dst) pair gets its own channel,
+    # which eliminates lightpath routing conflicts.
+    channels, pairs = {}, {}
+    ch = 1
+    for src in range(1, nodecount+1):
+        for dst in range(1, nodecount+1):
+            if not mesh and src != root and dst != root:
+                continue
+            # We ignore loopback for now
+            if src == dst: continue
+            channels[src, dst] = ch
+            pairs[ch] = (src, dst)
+            ch += 1
+    print("Channel assignment:")
+    print('\n'.join(f"ch{ch}: r{pair[0]} -> r{pair[1]}"
+                    for ch, pair in pairs.items()))
+
+    for i in range(1, nodecount+1):  # local node
+        # Pass all channels that are not added or dropped
+        passchannels = set(channels.values())
+        roadm = net[f'r{i}']
+        for j in range(1, nodecount+1):  # remote node
+            # Skip loopback connections
+            if i == j: continue
+            # Star topology only connects to/from root
+            if not mesh and root not in (i, j): continue
+            # Add and drop channels for i->j, j->i
+            addch, dropch = channels[i,j], channels[j,i]
+            print(roadm, f'add  ch{addch} port {addport(j)} -> {j}')
+            roadm.connect(addport(j), lineout(i,j), [addch])
+            print(roadm, f'drop ch{dropch} port {dropport(j)} <- {j}')
+            roadm.connect(linein(j,i), dropport(j), [dropch])
+            # Don't pass add/drop channels
+            passchannels.remove(addch)
+            passchannels.remove(dropch)
+            # Configure terminal uplinks and downlinks
+            terminal = net[f't{i}']
+            terminal.connect(
+                ethPort=ethport(j), wdmPort=uplink(j), channel=addch)
+            terminal.connect(
+                wdmPort=downlink(j), ethPort=ethport(j), channel=dropch)
+        # Pass all channels that were not added or dropped
+        if 1 < i < nodecount:
+            print(roadm, 'pass', passchannels)
+            roadm.connect(eastin, eastout, passchannels)
+            roadm.connect(westin, westout, passchannels)
+
+    # Turn on terminals
+    for i in range(1, nodecount+1):
+        net[f't{i}'].turn_on()
+
+
+class CLI( OpticalCLI ):
+    "CLI with config command"
+    def do_config(self, _line):
+        config(self.mn)
+
+
+if __name__ == '__main__':
+
+    cleanup()  # Just in case!
+    setLogLevel('info')
+    if len(argv) == 2 and argv[1] == 'clean': exit(0)
+
+    topo = UniLinearTopo2(nodecount=4)
+    net = Mininet(topo=topo, controller=None)
+    # restServer = RestServer(net)
+    net.start()
+    # restServer.start()
+    plotNet(net, outfile='unilinear2.png', directed=True,
+            layout='neato')
+    info( '*** Use config command to configure network \n' )
+    # config(net)
+    CLI(net)
+    # restServer.stop()
+    net.stop()

--- a/examples/uniring.py
+++ b/examples/uniring.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+
+"""
+uniring.py: unidirectional ring network,
+            with bidirectional Terminal links.
+"""
+
+from dataplane import ( OpticalLink,
+                        UnidirectionalOpticalLink as ULink,
+                        ROADM, Terminal,
+                        OpticalNet as Mininet,
+                        km, m, dB, dBm )
+
+# from rest import RestServer
+
+from mno.ofcdemo.demolib import OpticalCLI, cleanup
+from mno.examples.singleroadm import plotNet
+
+from mininet.topo import Topo
+from mininet.examples.linuxrouter import LinuxRouter
+from mininet.log import setLogLevel, info
+from mininet.clean import cleanup
+
+from functools import partial
+from sys import argv
+
+
+class OpticalTopo( Topo ):
+    "Topo with convenience methods for optical networks"
+
+    def wdmLink1( self, *args, **kwargs ):
+        "Convenience function to add a unidirectional link"
+        kwargs.update(cls=ULink)
+        self.addLink( *args, **kwargs )
+
+    def wdmLink2( self, *args, **kwargs ):
+        "Convenience function to add a bidirectional link"
+        kwargs.update(cls=OpticalLink)
+        self.addLink( *args, **kwargs )
+
+    def ethLink( self, *args, **kwargs ):
+        "Clarifying alias for addLink"
+        self.addLink( *args, **kwargs )
+
+    def addTerminal( self, *args, **kwargs ):
+        "Convenience alias for addSwitch( ... cls=Terminal )"
+        kwargs.setdefault( 'cls', Terminal )
+        return self.addSwitch( *args, **kwargs )
+
+    def addROADM( self, *args, **kwargs ):
+        "Convenience alias for addSwitch( ... cls=ROADM )"
+        kwargs.setdefault( 'cls', ROADM )
+        return self.addSwitch( *args, **kwargs )
+
+
+class UniRingTopo( OpticalTopo ):
+    """Parametrized unidirectional ring network
+       Switch/router port numbering (n==nodecount):
+       - 0: local port, connected to host
+       - 1..n: uplinks/downlinks to terminal transceivers
+               1..n and routers 1..n
+       Terminal port numbering:
+       - 1..n: transceiver WDM in/out ports (bidirectional)
+               to/from routers 1..n
+       - n+1..2*n ethernet ports (bidirectional)
+       ROADM port numbering:
+       - 1: line in
+       - 2: line out
+       - 3..txcount+2: add/drop ports to terminal
+    """
+    def build(self, power=0*dBm, nodecount=3):
+        """Create a simple(?) ring network with the specified
+           operational power and node and transceiver counts"""
+        self.nodecount = nodecount
+        self.txcount = txcount = nodecount
+        # Nodes/POPs: Terminals, ROADMs, switches, switches and hosts
+        terminals, roadms, switches, hosts = [], [], [], []
+        transceivers = tuple((f'tx{ch}', power, 'C')
+                             for ch in range(1, txcount+1))
+        tparams = {'transceivers': transceivers, 'monitor_mode': 'in'}
+        rparams = { 'monitor_mode': 'in'}
+        # was :{'wss_dict': {ch:(7.0,None) for ch in range(1,91)}}
+        sparams = {'cls': LinuxRouter}
+        for i in range(1, nodecount+1):
+            terminals += [self.addTerminal(f't{i}', **tparams)]
+            roadms += [self.addROADM(f'r{i}', **rparams)]
+            switches += [self.addNode(f's{i}', **sparams)]
+            hosts += [self.addHost(f'h{i}')]
+
+        # Optical link parameters
+        boost = ('boost', {'target_gain':17*dB})
+        aparams = {'target_gain': 50*km*.22 }
+        spans = [50*km, ('amp1', aparams), 50*km, ('amp2', aparams)]
+
+        linein, lineout = 1, 2
+        for i in range(nodecount):
+            # Unidirectional roadm->roadm optical links
+            self.wdmLink1(roadms[i], roadms[(i+1) % nodecount],
+                          port1=lineout, port2=linein,
+                          boost=boost, spans=spans)
+            # Bidirectional terminal <-> roadm optical links
+            for port in range(1, txcount+1):
+                self.wdmLink2(roadms[i], terminals[i],
+                              port1=port+lineout, port2=port,
+                              spans=[1*m])
+            # Terminal<->router and host<->router links
+            for txport in range(1, txcount+1):
+                self.ethLink(switches[i], terminals[i],
+                             port1=txport, port2=txcount+txport)
+            # Host-switch links
+            self.ethLink(hosts[i], switches[i], port2=txcount+1)
+
+
+
+# Helper functions
+
+linein, lineout = 1, 2
+
+def fwd(roadm, channels):
+    print(roadm, 'fwd', channels)
+    roadm.connect(linein, lineout, channels)
+def drop(roadm, dst, channel):
+    print(roadm, 'drop', channel)
+    roadm.connect(linein, lineout+dst, [channel])
+def add(roadm, src, channel):
+    print(roadm, 'add', channel)
+    roadm.connect(lineout+src, lineout, [channel])
+
+
+# Configuration (for testing, etc.)
+
+def config(net):
+    """Configure routed ring network.
+       This is complicated because we are configuring
+       both the optical and packet networks,
+       and because we're configuring a full mesh
+       of IP routers."""
+    info("*** Configuring network...\n")
+    nodecount = net.topo.nodecount
+    # Allocate channel for each pair of nodes
+    channels, ch = {}, 1
+    for i in range(1, nodecount+1):
+        for j in range(i+1, nodecount+1):
+            channels[i,j] = channels[j,i] = ch
+            ch += 1
+    allchannels = set(channels.values())
+    # Configure devices
+    for i in range(1, nodecount+1):
+        # ROADMs (unidirectional)
+        # Add and drop local channels and pass others
+        roadm = net[f'r{i}']
+        localchannels = set()
+        for j in range(1, nodecount+1):
+            if i == j: continue
+            addch, dropch = channels[i,j], channels[j,i]
+            add(roadm, j, addch)
+            drop(roadm, j, dropch)
+            localchannels.update({addch, dropch})
+        fwd(roadm, allchannels - localchannels)
+        # Terminals (bidirectional)
+        # Pass Ethernet ports through to WDM ports
+        # on the appropriate channel
+        terminal = net[f't{i}']
+        for j in range(1, nodecount+1):
+            if i == j: continue
+            ethPort, wdmPort = j+nodecount, j
+            info(f'*** {terminal}-eth{ethPort} <->'
+                 f' {terminal}-wdm{wdmPort}\n')
+            terminal.connect(ethPort=ethPort, wdmPort=wdmPort,
+                             channel=channels[i,j])
+        # Hosts and LinuxRouters
+        # Hosts use their local router as a gateway
+        host, router = net.get(f'h{i}', f's{i}')
+        ip = router.IP()
+        host.cmd('ip route flush all')
+        host.cmd('ip route add', ip, 'dev', host.defaultIntf())
+        host.cmd('ip route add 10.0.0.0/24 via', ip)
+        # Routers assign their IP address to all ports
+        for intf in router.intfs.values():
+            router.cmd('ip addr add dev', intf, ip)
+        router.cmd('ip route flush all')
+        # Routers set their local downlink route,
+        # As well as their point-to-point and next-hop
+        # routes to remote routers and hosts
+        for j in range(1, nodecount+1):
+            # Downlink to local host
+            if i == j:
+                dev = router.intfs[nodecount+1]
+                router.cmd('ip route add', host.IP(), 'dev', dev)
+            # Uplink to remote routers/hosts
+            else:
+                destrouter, dest  = net.get(f's{j}', f'h{j}')
+                dev  = router.intfs[j]
+                router.cmd('ip route add', destrouter.IP(),
+                           'dev', dev)
+                router.cmd('ip route add', dest.IP(),
+                           'via', destrouter.IP())
+    # Turn on Terminals/transceivers
+    for i in range(1, nodecount+1):
+        net[f't{i}'].turn_on()
+
+
+class CLI( OpticalCLI ):
+    "CLI with config command"
+    def do_config(self, _line):
+        config(self.mn)
+
+
+if __name__ == '__main__':
+
+    cleanup()  # Just in case!
+    setLogLevel('info')
+    if len(argv) == 2 and argv[1] == 'clean': exit(0)
+
+    topo = UniRingTopo(nodecount=4)
+    net = Mininet(topo=topo)
+    # restServer = RestServer(net)
+    net.start()
+    # restServer.start()
+    plotNet(net, outfile='uniring.png', directed=True)
+    info( '*** Use config command to configure network \n' )
+    # config(net)
+    CLI(net)
+    # restServer.stop()
+    net.stop()

--- a/examples/uniroadmchain.py
+++ b/examples/uniroadmchain.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+"""
+uniroadmchain.py: chain of unidirectional ROADMS without
+                  intermediate terminals
+
+This is mainly a test case rather than something that
+is actually useful, although signals can be monitored at
+the intermediate ROADMs.
+"""
+
+from dataplane import ( OpticalLink,
+                        UnidirectionalOpticalLink as ULink,
+                        ROADM, Terminal,
+                        OpticalNet as Mininet,
+                        km, m, dB, dBm )
+
+from mno.ofcdemo.demolib import OpticalCLI, cleanup
+from mno.examples.singleroadm import plotNet
+
+from mininet.topo import Topo
+from mininet.link import Link
+from mininet.nodelib import LinuxBridge
+from mininet.log import setLogLevel, info
+from mininet.clean import cleanup
+
+from sys import argv
+
+class UniRoadmChain(Topo):
+    """Two chains of unidirectional ROADMs linking two terminals
+       h1 <-> t1 -> re1 ... reN -> t2 <-> h2
+                 <- rwN ... rw1 <- t2
+    """
+
+    def build(self, power=0*dBm, roadmCount=3):
+        "Build simple unidirectional ROADM chain"
+        self.roadmCount = roadmCount
+        # Node config
+        transceivers = tuple((f'tx{ch}', power, 'C')
+                             for ch in range(1, roadmCount+1))
+        topts = {'cls': Terminal, 'transceivers': transceivers,
+                 'monitor_mode': 'in' }
+        ropts = {'cls': ROADM, 'monitor_mode': 'in',
+                 # { 'wss_dict': {ch:(7.0,None) for ch in range(1,91)}
+                 }
+        # Nodes
+        self.addHost('h1')
+        self.addHost('h2')
+        self.addSwitch('t1', **topts)
+        self.addSwitch('t2', **topts)
+        for i in range(1, roadmCount+1):
+            self.addSwitch(f're{i}', **ropts)
+            self.addSwitch(f'rw{i}', **ropts)
+        # Packet links
+        hostport = 1
+        self.addLink('h1', 't1', port1=hostport, port2=hostport)
+        self.addLink('h2', 't2', port1=hostport, port2=hostport)
+        # Eastbound and Westbound optical links
+        linein, lineout, uplink, downlink = 1, 2, 3, 4
+        self.addLink('t1', 're1', port1=uplink, port2=linein, cls=ULink)
+        self.addLink('t2', 'rw1', port1=uplink, port2=linein, cls=ULink)
+        self.addLink(f'rw{roadmCount}', 't1',
+                     port1=lineout, port2=downlink,
+                     cls=ULink, spans=[1*m])
+        self.addLink(f're{roadmCount}', 't2',
+                     port1=lineout, port2=downlink,
+                     cls=ULink, spans=[1*m])
+        boost = ('boost', {'target_gain':3.0*dB})
+        for i in range(1, roadmCount):
+            self.addLink(f're{i}', f're{i+1}',
+                         port1=lineout, port2=linein,
+                         cls=ULink, boost=boost, spans=[25*km])
+            self.addLink(f'rw{i}', f'rw{i+1}',
+                         port1=lineout, port2=linein,
+                         cls=ULink, boost=boost, spans=[25*km])
+
+    def configNet(self, net):
+        "Configure unidirectional ROADM chain"
+        info('*** Configuring network... \n')
+        hostport = 1
+        linein, lineout, uplink, downlink = 1, 2, 3, 4
+        roadmCount = self.roadmCount
+        # Terminal hostport<->(uplink,downlink)
+        for i in 1, 2:
+            net[f't{i}'].connect(hostport, wdmPort=uplink, channel=1,
+                                 wdmInPort=downlink )
+        # All ROADMs pass channel 1
+        for i in range(1, roadmCount+1):
+            net[f're{i}'].connect(linein, lineout, channels=[1])
+            net[f'rw{i}'].connect(linein, lineout, channels=[1])
+        # Power up transceivers
+        info('*** Turning on transceivers... \n')
+        net[f't1'].turn_on()
+        net[f't2'].turn_on()
+
+if __name__ == '__main__':
+
+    cleanup()  # Just in case!
+    setLogLevel('info')
+    if len(argv) == 2 and argv[1] == 'clean': exit(0)
+
+    topo = UniRoadmChain(roadmCount=4)
+    net = Mininet(topo=topo, controller=None)
+    net.start()
+    info('*** UniRoadmChain Example \n')
+    info(topo.__doc__, '\n')
+    plotNet(net, outfile='uniroadmchain.png', directed=True)
+    net.topo.configNet(net)
+    OpticalCLI(net)
+
+    net.stop()

--- a/node.py
+++ b/node.py
@@ -308,7 +308,8 @@ class LineTerminal(Node):
         # signals are originated at the Line Terminals,
         # thus in_port=-1 (it helps to update input intf of Terminal)
         # src_node=self always, needed for querying
-        self.include_optical_signal_in(optical_signal, in_port=-1, src_node=self)
+        # XXX Commented this out because it seems to add an extra unused signal/port
+        # self.include_optical_signal_in(optical_signal, in_port=-1, src_node=self)
 
         dst_node = self.port_to_node_out[out_port]
         # the goal of this function

--- a/ofcdemo/apsp.py
+++ b/ofcdemo/apsp.py
@@ -244,6 +244,7 @@ def configureTerminals( net, power=0.0):
                                channel=channel, power=power )
     print("*** Turning on terminals")
     for terminal in net.terminals:
+        print("***************", proxies[terminal])
         proxies[terminal].turn_on()
 
 


### PR DESCRIPTION
        Unidirectional ROADM and links 
    
        - add UnidirectionalOpticalLink
        - Update ROADM and Terminal to support unidirectional links
        - Fix some bottle parameter handling in dataplane.py
        - add wdmInPort parameter to Terminal.connect(), including
          rest.py and ofcdemo/fakecontroller.py
        - add examples/{uniring,unilinear1,unilinear2,uniroadmchain}.py
        - fix demolib.spans() to skip empty PhyLinks
        - add singleroadm.plotNet(..., directed, layout)
        - update OpticalCLI.do_signals()
        - update README
    
        Also:
        - don't add output signal as an input signal in assoc_tx_to_channel