### PR TITLE
Fix dataplane

### DIFF
--- a/dataplane.py
+++ b/dataplane.py
@@ -460,15 +460,6 @@ class ROADM( SwitchBase ):
 
     def __init__( self, name, **kwargs ):
         kwargs = kwargs.copy()
-        # FIXME: We need better explanations for these parameters
-        # FIXME: Also, the units seem to be wrong (power should be in dBm?)
-        roadm_linear_loss_dB = kwargs.pop( 'roadm_linear_loss_dB', 17)
-        operational_power_dB = kwargs.pop( 'operational_power_dB',  0)
-        reference_power = kwargs.setdefault( 'reference_power', operational_power_dB)
-        target_output_power_dB = kwargs.setdefault(
-            'target_output_power_dB', operational_power_dB - roadm_linear_loss_dB )
-        effective_output_power_dB = kwargs.setdefault(
-            'effective_output_power_dB', operational_power_dB )
         super().__init__( name, **kwargs )
 
     def start( self, _controllers ):

--- a/ofcdemo/apsp.py
+++ b/ofcdemo/apsp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 apsp.py: all-pairs-shortest-paths routing for ofc demo
@@ -239,14 +239,14 @@ def configureTerminals( net, power=0.0):
         wdmPorts = sorted( int(port) for port, intf in net.ports[ terminal ].items()
                            if 'wdm' in intf )
         channels = sum( net.remoteChannels[ i + 1 ], [] )
+        print(termProxy)
         for ethPort, wdmPort, channel in zip(ethPorts, wdmPorts, channels):
             termProxy.connect( ethPort=ethPort, wdmPort=wdmPort,
                                channel=channel, power=power )
     print("*** Turning on terminals")
     for terminal in net.terminals:
-        print("***************", proxies[terminal])
+        print(proxies[terminal])
         proxies[terminal].turn_on()
-
 
 def configurePacketSwitches( net ):
     "Configure Open vSwitch 'routers' using OpenFlow"

--- a/ofcdemo/demolib.py
+++ b/ofcdemo/demolib.py
@@ -258,14 +258,7 @@ class LinearRoadmTopo( OpticalTopo ):
             ('t%d' %t, 0*dBm, 'C') for t in range(1, txCount+1) ]
         terminal = self.addSwitch(
             't%d' % p, cls=Terminal, transceivers=transceivers )
-        roadm_linear_loss_dB = 17
-        operational_power_dB = 0
-        target_output_power_dB = operational_power_dB - roadm_linear_loss_dB
-        effective_output_power_dB = operational_power_dB
-        reference_power = operational_power_dB
-        roadm = self.addSwitch( 'r%d' % p,  cls=ROADM, target_output_power_dB=target_output_power_dB,
-                                effective_output_power_dB=effective_output_power_dB,
-                                reference_power=reference_power)
+        roadm = self.addSwitch( 'r%d' % p,  cls=ROADM )
         # Local links
         for port in range( 1, txCount+1 ):
             self.ethLink( router, terminal, port1=port, port2=port )


### PR DESCRIPTION
- use default ROADM args in dataplane.py
- use default ROADM args in demolib.py
 clean up apsp terminal config output

This should fix scripts which were broken by recent changes to the simulator API