### PR TITLE
fixed get_optical_signal function

### DIFF
--- a/node.py
+++ b/node.py
@@ -392,7 +392,6 @@ class LineTerminal(Node):
                     print("*** %s - %s.receiver.%s: Success!\ngOSNR: %f dB" %
                           (optical_signal, self.__class__.__name__, self.name, gosnr))
                     print("OSNR:", osnr)
-                    print("Power:", power)
 
                     signalInfoDict[optical_signal]['success'] = True
                     self.receiver_callback(in_port, signalInfoDict)


### PR DESCRIPTION
I just fixed the get_optical_signal function in node.py for the monitoring class. This also fixes the CLI command "osnr" in optical-mininet and allows us to retreive the metrics from Terminals as well as ROADMs for the visualization tool.