### PR TITLE
Fix removing ROADM rules in emulation mode

### DIFF
--- a/dataplane.py
+++ b/dataplane.py
@@ -489,7 +489,7 @@ class ROADM( SwitchBase ):
 
     def phyRemove( self, inport, outport, channels ):
         for channel in channels:
-            self.model.delete_switch_rule( ( inport, channel ) )
+            self.model.delete_switch_rule( inport, channel, switch=True )
 
     def restRulesHandler( self, query ):
         "Handle REST rules request"
@@ -525,7 +525,7 @@ class ROADM( SwitchBase ):
     def dpInstall( self, inport, outport, channels, cmd='add-flow' ):
         "Install a switching rule into the dataplane"
         for channel in channels:
-            flow = self.dpFlow( inport, outport, channel, 'add-flow' )
+            flow = self.dpFlow( inport, outport, channel, cmd )
             self.dpctl( cmd, flow )
 
     def dpRemove( self, inport, outport, channels ):
@@ -565,23 +565,16 @@ class ROADM( SwitchBase ):
         self.connect( port1, port2, channels, action )
         return 'OK'
 
-    def restDisconnectHandler( self, query ):
-        "REST remove handler"
-        return self.restConnectHandler( query, action='remove' )
-
     def connect( self, port1, port2, channels, action='install' ):
         """Install rule connecting port1 -> port2.
-           If interfaces are bidirectional, connect port2<->port1"""
+           If interfaces are bidirectional, connect port2<->port1
+           action: 'install' | 'remove' to install or remove rule"""
         intf1, intf2 = self.intfs[ port1 ], self.intfs[ port2 ]
         assert intf1.isInput() and intf2.isOutput()
         self.install( port1, port2, channels, action=action )
         # Install reverse rule if interfaces are bidirectional
         if intf1.isOutput() and intf2.isInput():
             self.install( port2, port1, channels, action=action )
-
-    def disconnect( self, port1, port2, channels, action='remove' ):
-        "Remove rule connecting port1 and port2"
-        self.connect( port1, port2, channels, action='remove' )
 
 
 class SimpleROADM( ROADM ):

--- a/examples/remove-singleroadm.sh
+++ b/examples/remove-singleroadm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -x
+
+set -e  # exit script on error
+
+# This script removes the ROADM rule installed by
+# config-singleroadm.sh
+
+# URL for REST server
+url="localhost:8080"; t1=$url; t2=$url; t3=$url; r1=$url
+curl="curl -s"
+
+echo "* Removing ROADM rule forwarding ch1 from t1 to t2"
+$curl "$r1/connect?node=r1&port1=1&port2=2&channels=1&action=remove"
+
+echo "* Monitoring signals at endpoints"
+for tname in t1 t2 t3; do
+    url=${!tname}
+    echo "* $tname"
+    $curl "$url/monitor?monitor=$tname-monitor"
+done
+
+echo "* Done."

--- a/examples/singleroadm.py
+++ b/examples/singleroadm.py
@@ -16,7 +16,7 @@ from ofcdemo.demolib import OpticalCLI as CLI
 
 from mininet.node import OVSBridge, Host
 from mininet.topo import Topo
-from mininet.log import setLogLevel, warning
+from mininet.log import setLogLevel, warning, info
 from mininet.clean import cleanup
 
 from os.path import dirname, realpath, join
@@ -97,10 +97,16 @@ def plotNet(net, outfile="singleroadm.png", directed=False, layout='circo'):
 
 def test(net):
     "Run config script and simple test"
+    info( '*** Configuring network and checking connectivity' )
+    hosts = net.get( 'h1', 'h2' )
     testdir = dirname(realpath(argv[0]))
     script = join(testdir, 'config-singleroadm.sh')
     run(script)
-    assert net.pingPair() == 0
+    assert net.ping(hosts, timeout=.5) == 0
+    info( '*** Removing ROADM rule and checking connectivity' )
+    script = join(testdir, 'remove-singleroadm.sh')
+    run(script)
+    assert net.ping(hosts, timeout=.5) == 100
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
- fix dpInstall() to properly pass its cmd argument to dpFlow
- which fixes /connect...&action=remove
- remove unused ROADM.{disconnect,restDisconnectHandler}
- add examples/remove-singleroadm.sh script for removing a rule
- test it in singleroadm.test()