### PR TITLE
Don't propagate empty preamp signals

### DIFF
--- a/node.py
+++ b/node.py
@@ -1019,7 +1019,8 @@ class Roadm(Node):
                             optical_signals_in_preamp.append(optical_signal)
 
                     # need to process signal before switch-based propagation
-                    self.preamp.propagate(optical_signals_in_preamp)
+                    if optical_signals_in_preamp:
+                        self.preamp.propagate(optical_signals_in_preamp)
 
     def compute_carrier_attenuation(self, in_port, amp=None):
         """


### PR DESCRIPTION
  
    Currently node.Roadm differentiates between add ports and line
    ports, and does not pass the add signals through the preamp.
    
    This means that there may be input signals that do not pass
    through the preamp, so Roadm.prepropgagation() calls
    Roadm.preamp.propagate(optical_signals_in_preamp==[])
    which causes trouble when compute_power_excursions() attempts
    to take the mean of an empty array. This results in NaN values
    for OSNR in the loop tests.
    
    This patch adds a check to Roadm.prepropagation() to not call
    preamp.propgate() with an empty signal list.