### PR TITLE
Fix sixnodestopo to run CLI properly by default

### DIFF
--- a/mininet_optical/examples/sixnodestopo.py
+++ b/mininet_optical/examples/sixnodestopo.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
     net.start()
     restServer.start()
     plotNet(net)
-    if not argv:
+    if len(argv) == 1:
         CLI(net)
     restServer.stop()
     net.stop()


### PR DESCRIPTION
- no arguments: run CLI
- arguments ('test'): don't run CLI