### PR TITLE
Build/CI refinements

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: apt update
+        run:  sudo apt update
+
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
@@ -16,10 +19,11 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: |
-             sudo apt update
-             make depend
+      - name: Build and install Mininet-Optical
+        run:  pip install build && make install
+
+      - name: Test "make depend"
+        run:  make depend
 
       - name: Install Mininet (master)
         run: |

--- a/makefile
+++ b/makefile
@@ -2,10 +2,6 @@ MODULE = mininet_optical
 SRCS = $(MODULE)/*.py $(MODULE)/*/*.py
 PKG = pyproject.toml setup.cfg setup.py
 
-all:
-
-build: wheel
-
 # Build python package (wheel/.whl file)
 # using pyproject-build (from python 'build' package)
 dist wheel: $(SRCS) $(PKG)
@@ -22,10 +18,13 @@ develop: $(SRCS) $(PKG)
 	sudo pip3 install --editable .
 
 # Install dependencies
+# In addition to our package dependencies, we install
+# build (for building) and pygraphviz (for examples/)
 depend: requirements.txt
-	sudo apt install python3-pygraphviz
 	python3 -m pip install -r requirements.txt
 	sudo python3 -m pip install -r requirements.txt
+	python3 -m pip install build
+	sudo apt install python3-pygraphviz
 
 # Run simulator tests
 simtest:


### PR DESCRIPTION
makefile

The 'make depend' target is useful for local development when
you haven't installed the package, and it now also installs
the python 'build' package to enable 'make dist' to work.

run-tests.yaml

- apt update is its own build step
- we now use (and test) 'make install' to build and install
- we now (sort of) test 'make depend' separately

It's tricky to test 'make depend' separately from 'make install'
so for now we just verify that it doesn't fail.