### PR TITLE
Simple netconf support for ofc21 demo

### DIFF
--- a/makecerts.sh
+++ b/makecerts.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e  # exit on error
+set -u  # exit on undefined var
+
+# Generate fake SSL certificates for netconf server/client
+
+ipaddr=127.0.0.1   # Agent listening address
+certdir=testcerts  # We create and destroy this dir to store test certs
+target=localhost   # hostname use in certs and passed to -target
+subj=/CN=$target   # Minimal specification for a cert
+
+echo "* Creating cert dir $certdir"
+
+mkdir -p $certdir
+
+echo '* Generating fake CA cert'
+
+openssl req -x509 -sha256 -nodes -days 2 -newkey rsa:2048 \
+        -keyout $certdir/fakeca.key -out $certdir/fakeca.crt \
+        -subj $subj
+
+echo '* Generating and signing fake server cert'
+
+openssl genrsa -out $certdir/fakeserver.key 2048
+
+openssl req -new -key $certdir/fakeserver.key \
+        -out $certdir/fakeserver.csr -subj $subj
+
+openssl x509 -req -days 2 -in $certdir/fakeserver.csr \
+        -CA $certdir/fakeca.crt -CAkey $certdir/fakeca.key \
+        -set_serial 01 -out $certdir/fakeserver.crt
+
+echo '* Generating fake client cert (self-signed)'
+
+openssl req -x509 -sha256 -nodes -days 2 -newkey rsa:2048 \
+       -keyout $certdir/fakeclient.key -out $certdir/fakeclient.crt \
+       -subj $subj
+
+echo "* Done."
+exit 0

--- a/makefile
+++ b/makefile
@@ -31,11 +31,15 @@ simtest:
 	tests/RunTests.sh
 
 # Run emulation tests
-emutest:
+emutest: certs
 	sudo examples/runtests.sh
 
 # Run all tests
 test: simtest emutest
+
+# Generate fake certs for netconf client/server
+certs: makecerts.sh
+	./makecerts.sh
 
 # Clean up non-source files
 clean:
@@ -43,3 +47,5 @@ clean:
 	find . -name -o -name '*.pyc' \
 	-o -name '*~' -o -name '#*' -o -name '*.png' \
 	| xargs rm -rf
+	rm -rf testcerts
+	rm -f mnoptical/ofcdemo/*.txt

--- a/mnoptical/examples/README.md
+++ b/mnoptical/examples/README.md
@@ -22,6 +22,11 @@ Config scripts (using REST API) for above:
 - unilinear2.py:    unidirectional linear network with 2-degree ROADMs
 - uniring.py:       unidirectional ring network
 - uniroadmchain.py: simple unidirectional ROADM chain(s) for testing
+- lroadmring.py:    unidirectional linear network with LROADM roadms
 
-The unidirectional examples currently use the internal control API
-and implement a 'config' CLI command to configure the network.
+Config script (using NETCONF API):
+
+- config_lroadmring.py: configure lroadmring.py for mesh connectivity
+
+The other unidirectional examples uni*.py currently use the internal
+control API, and implement a 'config' CLI command to configure the network.

--- a/mnoptical/examples/config_lroadmring.py
+++ b/mnoptical/examples/config_lroadmring.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+
+"""
+config_lroadrming.py: simple LumentumRing control script
+                      using ofcdemo.lumentum_NETCONF_API
+"""
+
+from mnoptical.ofcdemo.lroadm import (
+    LROADM, NetconfPortBase, username, password
+)
+
+from mnoptical.ofcdemo.lumentum_NETCONF_API import (
+    Lumentum, Lumentum_NETCONF
+)
+
+from mnoptical.examples.lroadmring import LumentumBase
+
+from mnoptical.ofcdemo.fakecontroller import TerminalProxy
+
+from subprocess import run
+from sys import argv
+
+# We allocate a channel for each (src, dst)/(dst,src) pair,
+# except for loopback (which we don't want anyway
+# because of the ethernet layer.)
+
+def allocChannels(N):
+    "Return channel map (src,dst)->ch for N-node mesh"
+    ch = 1
+    chmap = {}
+    for src in range(1, N+1):
+        for dst in range(src, N+1):
+            # Skip loopback
+            if src != dst:
+                chmap[src,dst] = chmap[dst,src] = ch
+                ch += 1
+    return chmap
+
+def genConnection(module, inport, outport, channel, loss=0.0):
+    "Return a netconf connection configuration string"
+    startfreq, endfreq = Lumentum.freqRangeGHz(channel)
+    connection = Lumentum.WSSConnection(
+        module=module, connection_id=channel, operation='in-service',
+        blocked='false', input_port=inport, output_port=outport,
+        start_freq=startfreq, end_freq=endfreq,
+        attenuation=loss, name=f'CH{channel}')
+    return connection
+
+def genConnections(i, N, chmap):
+    """Return netconf connection list connecting
+       roadm i to the other roadms in 1..N, each
+       via a dedicated channel. This enables full mesh
+       connectivity without channel collisions."""
+    connections = []
+    linein, lineout = LROADM.linein, LROADM.lineout
+    passchannels = set(chmap.values())
+    for dst in range(1, N+1):
+        if i == dst: continue
+        addport = LROADM.addbase + dst
+        dropport = LROADM.dropbase + dst
+        ch = chmap[i,dst]
+        assert ch == chmap[dst,i]
+        mux, demux = 1, 2
+        print(f'r{i} add {ch} from {addport}, drop {ch} to {dropport}')
+        incoming = genConnection(demux, linein, dropport, ch)
+        outgoing = genConnection(mux, addport, lineout, ch)
+        connections.extend([incoming, outgoing])
+        passchannels -= {ch}
+    print(f'r{i} pass channels {passchannels}')
+    for chin in passchannels:
+        inpass = genConnection(demux, linein, lineout, chin)
+        connections.append(inpass)
+    return connections
+
+def configRoadms(N, chmap):
+    "Configure LumentumRing ROADMs as a full mesh (NETCONF)"
+    # Initialize ROADM connections
+    roadms = [Lumentum(f'localhost:{NetconfPortBase+i}',
+                       username=username, password=password)
+              for i in range(1, N+1)]
+    # Configure ROADMs
+    for i, roadm in enumerate(roadms, start=1):
+        print(f'*** Configuring r{i}')
+        connections = genConnections(i, N, chmap)
+        reply = roadm.wss_add_connections(connections)
+    # Fetch connections
+    for i, roadm in enumerate(roadms, start=1):
+        connections = roadm.wss_get_connections()
+        info = Lumentum_NETCONF.parseConnections(connections)
+        print(f'*** r{i} Connections:')
+        print(info)
+
+def configTerminals(N, chmap):
+    "Connect each transceiver to a dedicated ethernet port (REST)"
+    # Note this will not work for hardware unless it supports our
+    # REST interface
+    ethbase = LumentumBase.ethbase
+    txbase, rxbase = LumentumBase.txbase, LumentumBase.rxbase
+    for i in range(1, N+1):
+        term = TerminalProxy(f't{i}', baseURL='http://localhost:8080/')
+        for dst in range(1, N+1):
+            if i == dst: continue
+            ch = chmap[i,dst]
+            # We need two connect() calls to connect our ethernet
+            # port to the split wdm tx/rx ports.
+            # Note that we aren't configuring power here and are just
+            # using the default tx power.
+            assert term.connect(ethPort=ethbase+dst, wdmPort=txbase+dst, channel=ch).ok
+            assert term.connect(wdmPort=rxbase+dst, ethPort=ethbase+dst, channel=ch).ok
+            assert term.turn_on().ok
+
+def configSwitches(N):
+    "Program OpenFlow switches with inbound and outbound rules"
+    # We assume the default IP addresses of 10.1 .. 10.4
+    # If those change, then this configuration will not work
+    # Note we are also assuming local OVS switches; remote switches
+    # should use the appropriate IP address and port.
+    hostport, ethbase = LumentumBase.hostport, LumentumBase.ethbase
+    listenPortBase = LumentumBase.listenPortBase
+    for i in range(1, N+1):
+        # Switch management IP address and passive OpenFlow port
+        switch = f'tcp:127.0.0.1:{listenPortBase+i}'
+        # Inbound: everything goes to host port
+        ip = '10.0.0.{i}'
+        for inport in range(1, N+1):
+            flow = f'in_port={inport},actions=output:{hostport}'
+            run(f'ovs-ofctl add-flow {switch} {flow}'.split(), check=True)
+        # Outbound: route to appropriate uplink port
+        for dst in range(1, N+1):
+            if i == dst: continue
+            ip = f'10.0.0.{dst}'
+            outport = ethbase + dst
+            for protocol in 'ip', 'icmp', 'arp':
+                flow = (f'in_port={hostport},{protocol},'
+                        f'ip_dst={ip},actions=output:{outport}')
+                run(f'ovs-ofctl add-flow {switch} {flow}'.split(), check=True)
+
+def config(N):
+    "Configure LumentumRing"
+    # Allocate channels
+    chmap = allocChannels(N)
+    print("*** Configuring ROADMs...")
+    configRoadms(N, chmap)
+    print("*** Configuring Terminals...")
+    configTerminals(N, chmap)
+    print("*** Configuring Switches...")
+    configSwitches(N)
+    return chmap
+
+def dumpChmap(N, chmap):
+    "Dump channel map"
+    for src in range(1,N+1):
+        print(f't{src}: ', end='')
+        for dst in range(1,N+1):
+            if src == dst: continue
+            ch = chmap[src,dst]
+            print(f'ch{ch}<->t{dst} ', end='')
+        print()
+
+if __name__ == '__main__':
+    # We test this as part of the lroadmring.py test
+    if 'test' in argv:
+        exit(0)
+    print("*** Configuring LROADM Ring Network...")
+    N = 4
+    chmap = config(N)
+    dumpChmap(N, chmap)

--- a/mnoptical/examples/lroadmring.py
+++ b/mnoptical/examples/lroadmring.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+"""
+lroadmring.py: ring test topology for LROADM
+"""
+
+from mnoptical.dataplane import (
+    UnidirectionalOpticalLink as ULink,
+    ROADM, Terminal,
+    OpticalNet as Mininet,
+    km, m, dB, dBm)
+
+from mnoptical.ofcdemo.demolib import OpticalCLI as CLI, cleanup
+from mnoptical.rest import RestServer
+from mnoptical.ofcdemo.lroadm import LROADM, NetconfPortBase
+from mnoptical.ofcdemo.netconfserver import NetconfServer
+from mnoptical.examples.singleroadm import plotNet
+
+from mininet.topo import Topo
+from mininet.log import setLogLevel, info, debug
+from mininet.node import OVSSwitch
+
+from os.path import dirname, realpath, join
+from subprocess import run
+from sys import argv
+
+### Default netconf username and password for testing
+username = 'admin'
+password = 'admin'
+
+### Simple LROADM() topologies
+
+class LumentumBase( Topo ):
+    """Simple ring topology using Lumentum-link ROADM model
+       nodes: hN<->sN<->tN<->rN (host/switch/terminal/roadm)
+       Note WDM links are unidirectional and ethernet
+       links are bidirectional."""
+
+    # Ethernet and WDM port numbering for Switch + Terminal
+    # Note Ethernet uses a single port for tx/rx while
+    # WDM uses split tx/rx ports and unidirectional links
+    ethbase = 0
+    hostport = 200  # Switch only
+    txbase = 100
+    rxbase = 200
+
+    # Passive OpenFlow TCP port base for packet switches
+    listenPortBase = 6653
+
+    # Make pylint happy
+    def __init__( self, *args, **kwargs ):
+        super().__init__( *args, **kwargs )
+        self.txcount = 1
+
+    # Helper functions
+
+    def wdmLink( self, src, dst, port1, port2, spans=(1*m,), **params ):
+        "Add a (default unidirectional) WDM link"
+        params.setdefault( 'cls', ULink )
+        params.setdefault( 'spans', [1.0*m] )
+        self.addLink( src, dst, port1, port2, **params )
+
+    # Node creation
+
+    @staticmethod
+    def nodeNames(i):
+        "Return host, switch, terminal, roadm names for node i"
+        assert not isinstance(i, bool)
+        return f'h{i} s{i} t{i} r{i}'.split()
+
+    def addNetworkNodes(self, i, power=0*dBm):
+        """Add a host-switch-terminal-ROADM nodes,
+           named hN, sN, tN, rN"""
+        # Add network elements
+        transceivers = tuple(
+            (f'tx{i}', power) for i in range( self.txcount ))
+        topts = {'transceivers': transceivers, 'monitor_mode': 'in'}
+        host, switch, term, roadm = self.nodeNames(i)
+        self.addHost(host)
+        self.addSwitch(switch, listenPort=self.listenPortBase+i)
+        self.addSwitch(term, cls=Terminal, **topts)
+        ncport = NetconfPortBase + i
+        self.addSwitch(roadm, cls=LROADM, netconfPort=ncport )
+
+    def addNodeLinks(self, i):
+        "Add internal links for network node i"
+        host, switch, term, roadm = self.nodeNames(i)
+        self.addLink(host, switch, port2=self.hostport)
+        for i in range(1, self.txcount+1):
+            # src, dst, port1, port2
+            self.addLink(switch, term, self.ethbase+i, self.ethbase+i)
+            # Terminal:txN -> ROADM:addN
+            self.wdmLink(
+                term, roadm, self.txbase+i, LROADM.addbase+i)
+            # ROADM:dropN -> Terminal:rxN
+            self.wdmLink(
+                roadm, term, LROADM.dropbase+i, self.rxbase+i)
+
+
+class LumentumRing( LumentumBase ):
+    """Unidrectional ring topology using Lumentum-like ROADM model
+       nodes: hN<->sN<->tN<->rN... (host/switch/terminal/roadm)
+       Note WDM links are unidirectional and ethernet
+       links are bidirectional."""
+
+    def build( self, N=4, txcount=16):
+        "Build lumentum ring"
+        self.N, self.txcount = N, txcount
+        # Add host, switch, terminal, roadm nodes
+        for i in range(1, N+1):
+            self.addNetworkNodes(i)
+            self.addNodeLinks(i)
+        # Connect roadm nodes
+        for i in range(1, N+1):
+            src, dst = f'r{i}', f'r{i%N+1}'
+            # Fiber length, compensating edfa
+            spans = [25*km, ('amp1', .2*25*dB)]
+            # Note: it's very important that line out goes to line in!
+            self.wdmLink(src, dst, LROADM.lineout, LROADM.linein, spans)
+
+def test(net):
+    "Run config script and simple test"
+    info( '** Checking that network is not configured...\n')
+    dropped = net.ping(net.hosts, timeout=.5)
+    assert dropped == 100
+    info( '*** Configuring network...\n' )
+    testdir = dirname(realpath(argv[0]))
+    script = join(testdir, 'config_lroadmring.py')
+    run(script)
+    info( '*** Checking connectivity...\n' )
+    dropped = net.ping(net.hosts, timeout=.5)
+    assert dropped == 0
+
+if __name__ == '__main__':
+    print("*** Cleaning up...")
+    cleanup()
+    if 'clean' in argv: exit(0)
+    setLogLevel('info')
+    topo = LumentumRing(N=4, txcount=4)
+    net = Mininet(topo=topo, controller=None)
+    restServer = RestServer(net)
+    netconfServer = NetconfServer(net, username=username, password=password)
+    plotNet(net, outfile='lumentumring.png', directed=True,
+            colorMap={LROADM: 'red', OVSSwitch: 'darkgreen'})
+    net.start()
+    restServer.start()
+    netconfServer.start()
+    test(net) if 'test' in argv else CLI(net)
+    netconfServer.stop()
+    restServer.stop()
+    net.stop()
+    info('Done.\n')

--- a/mnoptical/ofcdemo/Control_Test_Lum.py
+++ b/mnoptical/ofcdemo/Control_Test_Lum.py
@@ -1,3 +1,4 @@
+
 from mnoptical.ofcdemo.lumentum_NETCONF_API import Lumentum_NETCONF
 
 km = dB = dBm = 1.0
@@ -37,22 +38,19 @@ ADD_DROP = 1
 #   L1 ==== L2-L3 ===== L4-L5 ===== L6
 #
 # -------------------------------------
-##
+#
+
 Lumentum_NETCONF_Agent = Lumentum_NETCONF()
 
 AllLumName = ['L1', 'L2', 'L3', 'L4', 'L5', 'L6']
 
-NodeLink_to_LumentumLink = {}
-NodeLink_to_LumentumLink['r1', 'r2'], NodeLink_to_LumentumLink['r2', 'r1'], \
-NodeLink_to_LumentumLink['r2', 'r3'], NodeLink_to_LumentumLink['r3', 'r2'], \
-NodeLink_to_LumentumLink['r3', 'r4'], NodeLink_to_LumentumLink['r4', 'r3'] \
-    = ('L1', 'L2'), ('L2', 'L1'), ('L3', 'L4'), ('L4', 'L3'), ('L5', 'L6'), ('L6', 'L5')
+NodeLink_to_LumentumLink = {
+    ('r1','r2'):('L1','L2'), ('r2','r1'):('L2','L1'),
+    ('r2','r3'):('L3','L4'), ('r3','r2'):('L4','L3'),
+    ('r3','r4'):('L5','L6'), ('r4','r3'):('L6','L5')
+}
 
-LumentumName_to_IP = {}
-LumentumName_to_IP['L1'], LumentumName_to_IP['L2'], \
-LumentumName_to_IP['L3'], LumentumName_to_IP['L4'], \
-LumentumName_to_IP['L5'], LumentumName_to_IP['L6'] \
-    = '10.104.1.1', '10.104.1.2', '10.104.1.3', '10.104.1.4', '10.104.1.5', '10.104.1.6'
+LumentumName_to_IP = { f'L{i}':'10.104.1.{i}' for i in range(1, 6+1)}
 
 
 ####################### Lumentum END ############################
@@ -63,23 +61,8 @@ class Lumentum_Control_NETCONF(object):
     def __init__(self):
         Lumentum_NETCONF_Agent = Lumentum_NETCONF()
 
-        AllLumName = ['L1', 'L2', 'L3', 'L4', 'L5', 'L6']
-
-        NodeLink_to_LumentumLink = {}
-        NodeLink_to_LumentumLink['r1', 'r2'], NodeLink_to_LumentumLink['r2', 'r1'], \
-        NodeLink_to_LumentumLink['r2', 'r3'], NodeLink_to_LumentumLink['r3', 'r2'], \
-        NodeLink_to_LumentumLink['r3', 'r4'], NodeLink_to_LumentumLink['r4', 'r3'] \
-            = ('L1', 'L2'), ('L2', 'L1'), ('L3', 'L4'), ('L4', 'L3'), ('L5', 'L6'), ('L6', 'L5')
-
-        LumentumName_to_IP = {}
-        LumentumName_to_IP['L1'], LumentumName_to_IP['L2'], \
-        LumentumName_to_IP['L3'], LumentumName_to_IP['L4'], \
-        LumentumName_to_IP['L5'], LumentumName_to_IP['L6'] \
-            = '10.104.1.1', '10.104.1.2', '10.104.1.3', '10.104.1.4', '10.104.1.5', '10.104.1.6'
-
-
     def installPath(self, path, lightpathID, channel):
-        "intall switch rules on roadms along a lightpath with a signal channel"
+        "Install switch rules on roadms along a lightpath with a signal channel"
 
         half_channel_width = 25  # in GHz
         start_center_frequency = 191350.0  # in GHz
@@ -87,61 +70,74 @@ class Lumentum_Control_NETCONF(object):
         start_freq = str(center_frequency - half_channel_width)
         end_freq = str(center_frequency + half_channel_width)
 
-        # Two Lumentum nodes form a ROADM node, two WSSs forms a Lumentum node, module 1 is MUX WSS, module 2 is DEMUX WSS
-        # ingress and egress nodes only use MUX and DEMUX respectively. Intermediate nodes use DEMUX -> MUX.
+        # Two Lumentum nodes form a ROADM node, two WSSs forms a
+        # Lumentum node, module 1 is MUX WSS, module 2 is DEMUX WSS
+        # ingress and egress nodes only use MUX and DEMUX
+        # respectively. Intermediate nodes use DEMUX -> MUX.
+
         for i in range(len(path)):
             # intermediate ROADM nodes using 2 Lumentum nodes (4 WSSs)
             #print(i)
             if i != 0 and i != len(path) - 1:
-                Lumentum_this_out, Lumentum_next = NodeLink_to_LumentumLink[path[i], path[i + 1]]
-                Lumentum_previous, Lumentum_this_in = NodeLink_to_LumentumLink[path[i - 1], path[i]]
-                res = Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_in], status='in-service',
-                                                  conn_id=lightpathID,
-                                                  module_id=1, input_port=4100 + THRUPORT, output_port=4201,
-                                                  start_freq=start_freq, end_freq=end_freq, attenuation=10,
-                                                  block='false', name='CH' + str(channel))
+                Lumentum_this_out, Lumentum_next = \
+                    NodeLink_to_LumentumLink[path[i], path[i + 1]]
+                Lumentum_previous, Lumentum_this_in = \
+                    NodeLink_to_LumentumLink[path[i - 1], path[i]]
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_in], status='in-service',
+                    conn_id=lightpathID,
+                    module_id=1, input_port=4100 + THRUPORT, output_port=4201,
+                    start_freq=start_freq, end_freq=end_freq, attenuation=10,
+                    block='false', name=f'CH{channel}')
                 if not res:
                     return None
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_in], status='in-service',
-                                                  conn_id=lightpathID,
-                                                  module_id=2, input_port=5101, output_port=5200 + THRUPORT,
-                                                  start_freq=start_freq, end_freq=end_freq, attenuation=0,
-                                                  block='false', name='CH' + str(channel))
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_in], status='in-service',
+                    conn_id=lightpathID,
+                    module_id=2, input_port=5101, output_port=5200 + THRUPORT,
+                    start_freq=start_freq, end_freq=end_freq, attenuation=0,
+                    block='false', name=f'CH{channel}')
                 if not res:
                     return None
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_out], status='in-service',
-                                                  conn_id=lightpathID,
-                                                  module_id=1, input_port=4100 + THRUPORT, output_port=4201,
-                                                  start_freq=start_freq, end_freq=end_freq, attenuation=10,
-                                                  block='false', name='CH' + str(channel))
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_out], status='in-service',
+                    conn_id=lightpathID,
+                    module_id=1, input_port=4100 + THRUPORT, output_port=4201,
+                    start_freq=start_freq, end_freq=end_freq, attenuation=10,
+                    block='false', name=f'CH{channel}')
                 if not res:
                     return None
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_out], status='in-service',
-                                                  conn_id=lightpathID,
-                                                  module_id=2, input_port=5101, output_port=5200 + THRUPORT,
-                                                  start_freq=start_freq, end_freq=end_freq, attenuation=0,
-                                                  block='false', name='CH' + str(channel))
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_out], status='in-service',
+                    conn_id=lightpathID,
+                    module_id=2, input_port=5101, output_port=5200 + THRUPORT,
+                    start_freq=start_freq, end_freq=end_freq, attenuation=0,
+                    block='false', name=f'CH{channel}')
                 if not res:
                     return None
-                
+
             # Add/drop using Lumentum WSSs
             if i == 0 or i == len(path) - 1:
                 if i == 0:
-                    Lumentum_this_add_drop, Lumentum_next = NodeLink_to_LumentumLink[path[i], path[i + 1]]
+                    Lumentum_this_add_drop, Lumentum_next = \
+                        NodeLink_to_LumentumLink[path[i], path[i + 1]]
                 else:
-                    Lumentum_previous, Lumentum_this_add_drop = NodeLink_to_LumentumLink[path[i - 1], path[i]]
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_add_drop],
-                                                  status='in-service', conn_id=lightpathID,
-                                                  module_id=1, input_port=4100 + ADD_DROP, output_port=4201,
-                                                  start_freq=start_freq, end_freq=end_freq, attenuation=0,
-                                                  block='false', name='CH' + str(channel))
+                    Lumentum_previous, Lumentum_this_add_drop = \
+                        NodeLink_to_LumentumLink[path[i - 1], path[i]]
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_add_drop],
+                    status='in-service', conn_id=lightpathID,
+                    module_id=1, input_port=4100 + ADD_DROP, output_port=4201,
+                    start_freq=start_freq, end_freq=end_freq, attenuation=0,
+                    block='false', name=f'CH{channel}')
                 if not res:
                     return None
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_add_drop],
-                                                  status='in-service', conn_id=lightpathID,
-                                                  module_id=2, input_port=5101, output_port=5200 + ADD_DROP,
-                                                  start_freq=start_freq, end_freq=end_freq, attenuation=0,
-                                                  block='false', name='CH' + str(channel))
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_add_drop],
+                    status='in-service', conn_id=lightpathID,
+                    module_id=2, input_port=5101, output_port=5200 + ADD_DROP,
+                    start_freq=start_freq, end_freq=end_freq, attenuation=0,
+                    block='false', name=f'CH{channel}')
                 if not res:
                     return None
         return True
@@ -152,61 +148,67 @@ class Lumentum_Control_NETCONF(object):
         for i in range(len(path)):
             # del intermediate ROADM nodes using West+East Lumentum nodes (4 WSSs)
             if i != 0 and i != len(path) - 1:
-                Lumentum_this_out, Lumentum_next = NodeLink_to_LumentumLink[path[i], path[i + 1]]
-                Lumentum_previous, Lumentum_this_in = NodeLink_to_LumentumLink[path[i - 1], path[i]]
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_in], status='del',
-                                                  conn_id=lightpathID,
-                                                  module_id=1)
+                Lumentum_this_out, Lumentum_next = \
+                    NodeLink_to_LumentumLink[path[i], path[i + 1]]
+                Lumentum_previous, Lumentum_this_in = \
+                    NodeLink_to_LumentumLink[path[i - 1], path[i]]
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_in], status='del',
+                    conn_id=lightpathID, module_id=1)
                 if not res:
                     return None
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_in], status='del',
-                                                  conn_id=lightpathID,
-                                                  module_id=2)
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_in], status='del',
+                    conn_id=lightpathID, module_id=2)
                 if not res:
                     return None
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_out], status='del',
-                                                  conn_id=lightpathID,
-                                                  module_id=1)
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_out], status='del',
+                    conn_id=lightpathID,
+                    module_id=1)
                 if not res:
                     return None
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_out], status='del',
-                                                  conn_id=lightpathID,
-                                                  module_id=2)
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_out], status='del',
+                    conn_id=lightpathID,
+                    module_id=2)
                 if not res:
                     return None
             # del Add/Drop using East Lumentum (two WSSs)
             if i == 0 or i == len(path) - 1:
                 if i == 0:
-                    Lumentum_this_add_drop, Lumentum_next = NodeLink_to_LumentumLink[path[i], path[i + 1]]
+                    Lumentum_this_add_drop, Lumentum_next = \
+                        NodeLink_to_LumentumLink[path[i], path[i + 1]]
                 else:
-                    Lumentum_previous, Lumentum_this_add_drop = NodeLink_to_LumentumLink[path[i - 1], path[i]]
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_add_drop], status='del',
-                                                  conn_id=lightpathID,
-                                                  module_id=1)
+                    Lumentum_previous, Lumentum_this_add_drop = \
+                        NodeLink_to_LumentumLink[path[i - 1], path[i]]
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_add_drop], status='del',
+                    conn_id=lightpathID, module_id=1)
                 if not res:
                     return None
-                res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[Lumentum_this_add_drop], status='del',
-                                                  conn_id=lightpathID,
-                                                  module_id=2)
+                res = Lumentum_NETCONF_Agent._ConfigWSS(
+                    node_ip=LumentumName_to_IP[Lumentum_this_add_drop], status='del',
+                    conn_id=lightpathID, module_id=2)
                 if not res:
                     return None
-                
+
 
     def cleanAllROADMs(self):
         for name in AllLumName:
-            res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[name], status='del',
-                                              conn_id='all',
-                                              module_id=1)
+            res = Lumentum_NETCONF_Agent._ConfigWSS(
+                node_ip=LumentumName_to_IP[name], status='del',
+                conn_id='all', module_id=1)
             if not res:
-                    return None
-            res=Lumentum_NETCONF_Agent._ConfigWSS(node_ip=LumentumName_to_IP[name], status='del',
-                                              conn_id='all',
-                                              module_id=2)
+                return None
+            res = Lumentum_NETCONF_Agent._ConfigWSS(
+                node_ip=LumentumName_to_IP[name], status='del',
+                conn_id='all', module_id=2)
             if not res:
                     return None
         return True
 
-            
+
     def channel_monitor(self, path, lightpathID):
         Lumentum_Source, Lumentum_next = NodeLink_to_LumentumLink[path[0], path[1]]
         Lumentum_previous, Lumentum_Desination = NodeLink_to_LumentumLink[path[-2], path[-1]]
@@ -214,12 +216,12 @@ class Lumentum_Control_NETCONF(object):
         D_WSS_info = Lumentum_NETCONF_Agent._WSSMonitor(LumentumName_to_IP[Lumentum_Desination])
         if not S_WSS_info['MUX'] or not D_WSS_info['DEMUX']:
             return None,None
-        
+
         return (S_WSS_info['MUX'][str(lightpathID)]), (D_WSS_info['DEMUX'][str(lightpathID)])
 
 
 def Control_Test():
-    " set up a lightpath from r4 to r1 bidirectionally with channel 5"
+    "Set up a lightpath from r4 to r1 bidirectionally with channel 5"
 
     ####### Lumentum Test ########
     path = ['r4', 'r3', 'r2', 'r1']
@@ -230,4 +232,5 @@ def Control_Test():
     #Controller.uninstallPath(path=path, lightpathID=1)
 
 
-Control_Test()
+if __name__ == '__main__':
+    Control_Test()

--- a/mnoptical/ofcdemo/demo_hwtopo.py
+++ b/mnoptical/ofcdemo/demo_hwtopo.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+"""
+lroadmtest.py: simple netconf control test for lroadm.py
+"""
+
+from mnoptical.ofcdemo.Control_Test_Lum import (
+    Lumentum_Control_NETCONF, LumentumName_to_IP, Control_Test )
+
+from mnoptical.ofcdemo.Demo_Control import TrafficTest
+
+from sys import argv
+
+NetconfPortBase = 1830
+
+def fixIPMap(nameToIP):
+    "Fix name-to-IP map for Mininet"
+    for i in range(1, 7):
+        port = NetconfPortBase +i
+        nameToIP[f'L{i}'] = f'localhost:{port}'
+
+def Control_Test():
+    " set up a lightpath from r4 to r1 bidirectionally with channel 5"
+
+    ####### Lumentum Test ########
+    path = ['r4', 'r3', 'r2', 'r1']
+    Controller = Lumentum_Control_NETCONF()
+    print('*** Cleaning ROADMs')
+    Controller.cleanAllROADMs()
+    Controller.installPath(path=path, channel=5, lightpathID=1)
+    Controller.channel_monitor(path=path, lightpathID=1)
+    print("Press enter to continue...")
+    input()
+    Controller.uninstallPath(path=path, lightpathID=1)
+
+if __name__ == '__main__':
+
+    # Fix name-to-ip map for Mininet
+    fixIPMap(LumentumName_to_IP)
+
+    print("*** IP Address Map:")
+    print(LumentumName_to_IP)
+
+    if 'test' in argv:
+        Control_Test()
+    else:
+        TrafficTest(Mininet_Enable=False)

--- a/mnoptical/ofcdemo/fakecontroller.py
+++ b/mnoptical/ofcdemo/fakecontroller.py
@@ -100,18 +100,21 @@ class TerminalProxy( SwitchProxy ):
         # print('connect', params)
         r = self.get( 'connect', params=params )
         # print( r )
+        return r
 
     def reset(self):
         params = dict(node=self.name)
         # print('reset', params)
         r = self.get('reset', params=params)
         # print(r)
+        return r
 
     def turn_on(self):
         params = dict(node=self.name)
         # print('turn_on', params)
         r = self.get('turn_on', params)
         # print(r)
+        return r
 
 
 class ROADMProxy( SwitchProxy ):
@@ -125,11 +128,13 @@ class ROADMProxy( SwitchProxy ):
         # print('connect', params)
         r = self.get( 'connect', params=params)
         # print( r )
+        return r
 
     def reset(self):
         params = dict(node=self.name)
         # print('reset', params)
         r = self.get('reset', params=params)
+        return r
 
 
 ### Configuration Retrieval

--- a/mnoptical/ofcdemo/lroadm.py
+++ b/mnoptical/ofcdemo/lroadm.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+
+"""
+lroadm.py:
+
+A simple Lumentum-like ROADM (LROADM) with a (somewhat) compatible NETCONF API
+This 1-degree ROADM corresponds to half of a hardware ROADM.
+
+"""
+
+from mnoptical.dataplane import (
+    UnidirectionalOpticalLink as ULink,
+    ROADM, Terminal,
+    OpticalNet as Mininet,
+    km, m, dB, dBm)
+
+from mnoptical.ofcdemo.demolib import OpticalCLI as CLI, cleanup
+from mnoptical.rest import RestServer
+from mnoptical.ofcdemo.netconfserver import NetconfServer
+from mnoptical.examples.singleroadm import plotNet
+
+from mininet.topo import Topo
+from mininet.log import setLogLevel, info, debug
+from mininet.node import OVSSwitch
+
+from sys import argv
+
+### Default netconf username and password for testing
+username = 'admin'
+password = 'admin'
+
+### Lumentum ROADM class
+
+NetconfPortBase = 1830  # Control port base
+
+class LROADM( ROADM ):
+    "Lumentum-like ROADM with a netconf port"
+
+    # Default netconf username and password
+    username = 'admin'
+    password = 'admin'
+
+    # Port number constants and helper functions
+    linein, lineout = 5101, 4201
+    addbase, dropbase = 4100, 5200
+    def addport(self, i): return self.addbase + i
+    def dropport(self, i): return self.dropbase + i
+
+    def __init__( self, *args, netconfPort=None, **kwargs):
+        if not netconfPort:
+            raise Exception('Lumentum: netconfPort required')
+        self.username = kwargs.pop('username', self.username)
+        self.password = kwargs.pop('password', self.password)
+        super().__init__(*args, **kwargs)
+        self.netconfPort = netconfPort
+
+    def __str__( self ):
+        return self.name

--- a/mnoptical/ofcdemo/netconfserver.py
+++ b/mnoptical/ofcdemo/netconfserver.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+netconfserver.py: simple netconf server for mininet-optical
+
+TODO:
+
+- implement boost/preamp configuration for new simulator version
+- improve configuration report
+- implement configuration updates
+
+"""
+
+# pylint: disable=no-name-in-module
+from lxml.etree import (QName, Element, SubElement, tostring, fromstring,
+                        tounicode)
+
+from netconf import nsmap_update
+from netconf.server import SSHUserPassController, NetconfSSHServer
+from netconf.util import (elm, subelm, leaf_elm, filter_results,
+                          xpath_filter_result, filter_to_xpath)
+
+from os.path import dirname
+from threading import Thread
+from time import sleep
+
+from mininet.log import info
+from mnoptical.dataplane import ROADM
+from mnoptical.units import abs_to_db
+
+linein = 5101
+lineout = 4201
+
+### Parameters
+
+### XML namespaces
+
+EdfaNsmap = { 'lotee': 'http://www.lumentum.com/lumentum-ote-edfa'}
+ConnNsmap = { 'lotet': 'http://www.lumentum.com/lumentum-ote-connection'}
+nsmap =  { 'nc': 'urn:ietf:params:xml:ns:netconf:base:1.0' }
+for m in EdfaNsmap, ConnNsmap:
+    nsmap.update( m )
+
+nsmap_update(nsmap)
+
+### Netconf connection parameters
+SSLKeyFile = f"{dirname(__file__)}/../../testcerts/fakeserver.key"
+NetconfPortBase = 1830  # default is 830 but we use 1831+
+
+
+Debug = False
+
+def debug(*args, **kwargs):
+    "debug print"
+    if Debug:
+        print(''.join(map(str, args)), **kwargs)
+
+### Helper functions
+
+def xmlstring( atree ):
+    "Return lxml element as a string"
+    if atree is not None:
+        return tostring(atree, pretty_print=True).decode()
+
+### Connection parsing
+
+configNs = dict( nc="urn:ietf:params:xml:ns:netconf:base:1.0",
+                 lotet='http://www.lumentum.com/lumentum-ote-connection')
+
+def parseconn( conn ):
+    "Parse config connection and return <dn>,<config> as dicts"
+
+    def convert( value ):
+        value = value.strip()
+        if isinstance( value, str ) and value and value[0].isnumeric():
+            return ( float( value ) if '.' in value or 'e' in value
+                     else int( value ) )
+        return value
+
+    def textToDict( text ):
+        "Convert 'foo=1;bar=2...' to dict"
+        result = {}
+        entries = text.split( ';' )
+        for entry in entries:
+            k, v = entry.split( '=' )
+            result[ k.strip() ] = convert( v.strip() )
+        return result
+
+    def freqToChannels( startfreq, endfreq ):
+        half_channel_width = 25  # in GHz
+        start_center_frequency = 191350  # in GHz
+        startfreq, endfreq = int(startfreq), int(endfreq)
+        startfreq += half_channel_width
+        channels = []
+        ch = (startfreq - start_center_frequency)//50
+        assert ch >= 0
+        while startfreq < endfreq:
+            channels.append( ch )
+            startfreq += 50
+        return channels
+
+    dn, config, module, inport, outport, channels = (
+        None, None, None, None, None, [] )
+
+    for item in conn:
+        name = QName(item.tag).localname
+        if name == 'dn': dn = item
+        elif name == 'config': config = item
+    if dn is not None:
+        dn = textToDict( dn.text )
+        module = dn[ 'module' ]
+    if config is not None:
+        config = { QName( item.tag ).localname: item.text
+                   for item in config }
+        for k, v in config.items():
+            if isinstance( v, str ) and ';' in v:
+                config[ k ] = textToDict( v )
+            else:
+                config[ k ] = convert( v )
+    if config:
+        startfreq, endfreq = config[ 'start-freq' ], config[ 'end-freq' ]
+        inport = config[ 'input-port-reference' ][ 'port' ]
+        outport = config[ 'output-port-reference' ][ 'port' ]
+        channels = freqToChannels( startfreq, endfreq )
+    return dn, config, module, inport, outport, channels
+
+
+### Per-ROADM netconf agent
+
+class NetconfAgent:
+
+    "Netconf agent for single (Lumentum-like) ROADM"
+
+    def __init__( self, roadm, port=None, username=None, password=None):
+        "Create netconf agent for roadm"
+
+        port = port or roadm.netconfPort
+        username = username or roadm.username
+        password = password or roadm.password
+
+        self.roadm = roadm
+        self.connections = {}
+
+        info( f'*** Starting Netconf Agent for {roadm} on port {port}\n' )
+
+        controller = SSHUserPassController(
+            username=username, password=password )
+
+        self.server = NetconfSSHServer(
+            server_ctl=controller, server_methods=self,
+            port=port, host_key=SSLKeyFile, debug=True)
+        assert self.server
+
+    def nc_append_capabilities( self, caps ):
+        "Add our base netconf capability"
+        # debug("NC_APPEND_CAPABILITIES")
+        subelm( caps, 'capability').text = \
+            "urn:ietf:params:netconf:capability:xpath:1.0"
+        for cap in nsmap.values():
+            subelm( caps, 'capability').text = cap
+
+    def rpc_get( self, session, rpc, filter_or_none):
+        "Get some config data"
+        # debug( "RPC_GET", tounicode(rpc))
+        data = elm('nc:data')
+        self.add_config(data)
+        # FIXME: workaround for filtering not working properly
+        if False and filter_or_none and 'connections' in tounicode(
+                filter_or_none):
+            xpath = '/connections/connection'
+            data = xpath_filter_result( data, xpath)
+        debug("RETURNING", tounicode(data, pretty_print=True))
+        return data
+
+    def rpc_get_config( self, session, rpc, source_elm, filter_or_none ):
+        """Passed the source element"""
+        debug( "GET_CONFIG!!!" )
+        data = elm( "nc:data" )
+        self.add_config(data)
+        return data
+
+    def rpc_edit_config( self, session, rpc, source_elm,
+                         filter_or_none ):
+        debug("EDIT_CONFIG")
+        data = elm("nc:data")
+        config = rpc.xpath(
+            '/nc:rpc/nc:edit-config/nc:config/lotet:connections/'
+            'lotet:connection', namespaces=configNs)
+        for conn in config:
+            dn, config, module, inport, outport, channels = parseconn(
+                conn )
+            self.updateConnections( inport, outport, channels, conn )
+            if dn and config:
+                print(self.roadm, "connecting", inport, outport, channels)
+                self.roadm.connect( inport, outport, channels )
+        data.append( elm('ok') )
+        return data
+
+    def updateConnections( self, inport, outport, channels, conn ):
+        # Delete any overlapping connections
+        # (assume they are auto-deleted in emulator as well)
+        for i, o, c in list( self.connections.keys() ):
+            if ((i == inport or o == outport) and
+                c.intersection( channels )):
+                del self.connections[i,o,c]
+        self.connections[ inport, outport, frozenset(channels) ] = conn
+        debug(" UPDATED CONNECTIONS ")
+        debug(self.connections)
+
+    def rpc_disable_als( self, session, rpc, *params ):
+        debug("DISABLE_ALS")
+        data = elm("nc:data")
+        return data
+
+    def rpc_remove_all_connections( self, session, rpc, *params ):
+        debug("remove_all_connections", self.roadm)
+        self.roadm.reset()
+        data = elm("nc:data")
+        data.append( elm('ok') )
+        return data
+
+    def rpc_delete_connection( self, session, rpc, *params):
+        debug("DELETE_CONNECTION")
+        dn = rpc[0][0]
+        self.delete_connection_dn(dn)
+        data = elm('nc:data')
+        data.append( elm('ok') )
+        return data
+
+    def delete_connection_dn(self, dn):
+        for spec in self.connections.keys():
+            conn = self.connections[spec]
+            for entry in conn:
+                if entry.tag.endswith('dn') and entry.text == dn.text:
+                    inport, outport, channels = spec
+                    debug("removing connection", inport, outport, channels)
+                    self.roadm.connect( inport, outport, channels, action='remove')
+                    del self.connections[spec]
+                    return
+
+    def stop( self ):
+        "Shut down Netconf server"
+        self.server.close()
+        self.server.join()
+
+    def add_config( self, data ):
+        "Add config entries to rpc return data"
+        # XXX to be implemented:
+        # self.add_ports( data )
+        self.add_edfas( data )
+        self.add_connections( data )
+
+    def add_edfas( self, data ):
+        "Add EDFA config to data"
+        entries = subelm( data, 'edfas', nsmap=EdfaNsmap )
+        boost, preamp = 1, 2
+        for i in range(1,3):
+            edfa = subelm( entries, 'edfa')
+            state = subelm( edfa, 'state' )
+            state.append( leaf_elm( 'input-power', 0 ) )
+            state.append( leaf_elm( 'output-power', 0 ) )
+            if i == boost:
+                voas = subelm( state, 'voas' )
+                voa = subelm( voas, 'voa' )
+                voa.append( leaf_elm( 'voa-input-power', 0) )
+                voa.append( leaf_elm( 'voa-output-power', 0) )
+                voa.append( leaf_elm( 'voa-attenuation', 0) )
+            conf = subelm( edfa, 'config' )
+            conf.append( leaf_elm( 'lotee:target-gain', 0) )
+            conf.append( leaf_elm( 'lotee:target-power', 0) )
+            conf.append( leaf_elm( 'lotee:target-gain-tilt', 0) )
+            conf.append( leaf_elm( 'lotee:control-mode', 0) )
+            conf.append( leaf_elm( 'lotee:gain-switch-mode', 0) )
+            conf.append( leaf_elm( 'lotee:maintenance-state', 0) )
+
+    def findInputPower( self, ch ):
+        "Return first signal power at ROADM's line input for channel"
+        roadm = self.roadm.model
+        portsigs = roadm.port_to_optical_signal_in
+        found, power = None, None
+        for port in [linein]:
+            for signal in portsigs[port]:
+                if signal.index == ch:
+                    found = signal
+                    break
+        if found:
+            state = signal.loc_in_to_state.get( roadm, None)
+            if state:
+                power = abs_to_db(state['power'])
+        return power
+
+
+    def findOutputPower( self, ch ):
+        "Return first signal power at ROADM's line output for channel"
+        roadm = self.roadm.model
+        portsigs = roadm.port_to_optical_signal_out
+        found, power = None, None
+        for port in [lineout]:
+            for signal in portsigs[port]:
+                if signal.index == ch:
+                    found = signal
+                    break
+        if found:
+            state = signal.loc_in_to_state.get( roadm, None)
+            if state:
+                power = abs_to_db(state['power'])
+        return power
+
+    def add_connections( self, data):
+        connections = SubElement( data, 'connections',
+                                  nsmap={None:nsmap['lotet']} )
+        for spec in self.connections.keys():
+            conn = self.connections[spec]
+            inport, outport, channels = spec
+            if not conn.xpath('state'):
+                state = subelm(conn, 'state')
+                iat = subelm(state, 'input-channel-attributes')
+                ipower = subelm(iat, 'power')
+                oat = subelm(state, 'output-channel-attributes')
+                opower = subelm(oat, 'power')
+            ipower = conn.xpath(
+                'state/input-channel-attributes/power')[0]
+            opower = conn.xpath(
+                'state/output-channel-attributes/power')[0]
+            # We currently only handle a single signal
+            assert len(channels) == 1
+            ch = list(channels)[0]
+            ipow = self.findInputPower(ch)
+            opow = self.findOutputPower(ch)
+            ipower.text = str(ipow) if ipow is not None else '-50'
+            opower.text = str(opow) if opow is not None else '-50'
+            connections.append( conn )
+        return
+
+
+class NetconfServer:
+    "Collection of Netconf agents for Mininet-Optical network"
+
+    def __init__( self, net, **params):
+        self.net = net
+        self.servers = []
+        self.params = params
+
+    def start( self ):
+        "Start up netconf agents"
+        roadms = [ s for s in self.net.switches
+                   if hasattr( s, 'netconfPort' ) ]
+        for roadm in roadms:
+            server = NetconfAgent(
+                roadm, port=roadm.netconfPort, **self.params )
+            self.servers.append( server )
+
+    def stop( self ):
+        for s in self.servers:
+            s.stop()
+
+
+def runTestServer():
+    "Run netconf server in test mode"
+    class DummyRoadm:
+        netconfPort = 1831
+        username = 'dummy'
+        password = 'dummy'
+    server = NetconfAgent(DummyRoadm())
+    print( '* Starting netconf Agent()')
+    try:
+        while True: sleep( 30 )
+    except KeyboardInterrupt:
+        print( '* Stopping netconf server\n' )
+        server.stop()
+
+
+if __name__ == '__main__':
+    runTestServer()
+    print( '* Done.' )

--- a/mnoptical/ofcdemo/run-nccontrol.sh
+++ b/mnoptical/ofcdemo/run-nccontrol.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+rootdir=$(dirname $0)/../..
+
+echo '*** Running netconf controller against hwtopo'
+PYTHONPATH=${rootdir} python3 -m mnoptical.ofcdemo.demo_hwtopo

--- a/mnoptical/ofcdemo/run-nctopo.sh
+++ b/mnoptical/ofcdemo/run-nctopo.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+rootdir=$(dirname $0)/../..
+
+echo '*** Creating netconf server certs'
+(cd ${rootdir} && make certs)
+
+echo "*** Starting up hwtopo.py with netconf"
+sudo HOME=~ PYTHONPATH=${rootdir} python3 -m mnoptical.ofcdemo.hwtopo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 numpy
 scipy
 bottle
+lxml
+xmltodict
+netconf
+ncclient


### PR DESCRIPTION
- added ofcdemo.lroadm
  This is a simple Lumentum-like 1-degree ROADM

- added ofcdemo.netconfserver
  This is a simple netconf agent that supports
  the OFC 2021 demo topology.

- added ofcdemo.demo_hwtopo.py as well as
  ofcdemo/run-{nctopo,nccontrol}.sh scripts
  This is a version of the ofc21 demo which
  replicates the COSMOS testbed topology and is largely
  compatible with the hardware testbed control
  script (though with different IP addresses.)

- added examples.lroadmring (ring network test)
  This is a simple ring network made from LROADMs

- added examples.config_lroadmring (controller script)
  This is a complete configuration script for
  lroadmring.py, using netconf, rest and openflow

- added make certs to create SSL certs for netconf tests

- cleaned up lumentum_NETCONF_API, and enabled
  connection reuse