### PR TITLE
Change wdg_id of None from random to 'linear' (flat)

### DIFF
--- a/mnoptical/node.py
+++ b/mnoptical/node.py
@@ -1232,6 +1232,8 @@ class Amplifier(Node):
         :return: Return wavelength dependent gain array
         """
         if wdg_id is None:
+            wdg_id = 'linear'
+        elif wdg_id == 'randomize':
             return list(random.choice(list(ripple_functions.values())))
         return list(ripple_functions[wdg_id])
 


### PR DESCRIPTION
It makes more sense that None would imply a lack of WDG
rather than randomly choosing.

wdg_id==None: use 'linear' (flat) WDG function

wdg_id='randomize': randomly choose one of the three available
WDG functions ('linear', 'wdg1', 'wdg2').