### PR TITLE
lroadm and netconf fixes

### DIFF
--- a/mnoptical/ofcdemo/lroadm.py
+++ b/mnoptical/ofcdemo/lroadm.py
@@ -14,6 +14,7 @@ from mnoptical.dataplane import (
     OpticalNet as Mininet,
     km, m, dB, dBm)
 
+from mnoptical.node import Amplifier
 from mnoptical.ofcdemo.demolib import OpticalCLI as CLI, cleanup
 from mnoptical.rest import RestServer
 from mnoptical.ofcdemo.netconfserver import NetconfServer
@@ -46,12 +47,18 @@ class LROADM( ROADM ):
     def addport(self, i): return self.addbase + i
     def dropport(self, i): return self.dropbase + i
 
-    def __init__( self, *args, netconfPort=None, **kwargs):
+    def __init__( self, name, *args, netconfPort=None, **kwargs):
         if not netconfPort:
             raise Exception('Lumentum: netconfPort required')
         self.username = kwargs.pop('username', self.username)
         self.password = kwargs.pop('password', self.password)
-        super().__init__(*args, **kwargs)
+        # FIXME: for some reason the preamp causes the
+        # lroadmring.py test to explode
+        if False and 'preamp' not in kwargs:
+            kwargs['preamp'] = Amplifier(name+'-pre', target_gain=0*dB, preamp=True)
+        if 'boost' not in kwargs:
+            kwargs['boost'] = Amplifier(name+'-boost', target_gain=0*dB, boost=True)
+        super().__init__(name, *args, **kwargs)
         self.netconfPort = netconfPort
 
     def __str__( self ):

--- a/mnoptical/ofcdemo/lumentum_NETCONF_API.py
+++ b/mnoptical/ofcdemo/lumentum_NETCONF_API.py
@@ -391,7 +391,7 @@ class Lumentum:
         "Return frequency range (startGHz, endGHz) for channel"
         half_channel_width = 25  # in GHz
         start_center_frequency = 191350.0  # in GHz
-        center_frequency = start_center_frequency + channel * 50
+        center_frequency = start_center_frequency + (channel-1) * 50
         start_freq = str(center_frequency - half_channel_width)
         end_freq = str(center_frequency + half_channel_width)
         return start_freq, end_freq
@@ -409,11 +409,12 @@ class Lumentum:
         """
         connections = []
         for i in range(96):
+            channel = i+1
             center_frequency = start_center_frequency + i * channel_spacing
             start_freq, end_freq = Lumentum.freqRangeGHz(channel)
             connection = Lumentum.WSSConnection(
                 module,
-                str(i + 1),
+                str(channel),
                 'in-service',
                 'false',
                 input_port,
@@ -421,7 +422,7 @@ class Lumentum:
                 str(start_freq),
                 str(end_freq),
                 loss,
-                'CH' + str(i + 1)
+                'CH' + str(channel)
             )
             connections.append(connection)
         return connections

--- a/mnoptical/ofcdemo/netconfserver.py
+++ b/mnoptical/ofcdemo/netconfserver.py
@@ -89,13 +89,15 @@ def parseconn( conn ):
         half_channel_width = 25  # in GHz
         start_center_frequency = 191350  # in GHz
         startfreq, endfreq = int(startfreq), int(endfreq)
-        startfreq += half_channel_width
         channels = []
-        ch = (startfreq - start_center_frequency)//50
-        assert ch >= 0
-        while startfreq < endfreq:
-            channels.append( ch )
-            startfreq += 50
+        ch = 1 + (startfreq-start_center_frequency)//50
+        chfreq = start_center_frequency + (ch-1)*50
+        while chfreq <= endfreq:
+            # Assume client will ask for at least 40GHz
+            if startfreq <= chfreq-20 and chfreq+20 <=endfreq:
+                channels.append( ch )
+            ch += 1
+            chfreq += 50
         return channels
 
     dn, config, module, inport, outport, channels = (


### PR DESCRIPTION
- add default boost amp for lroadm
- unfortunately preamp is *broken* atm! need to fix
- fix channel number in unused gen_dwdm_connections()
- be more forgiving/accurate? (+/- 20 Ghz) for channel selection
  in netconfserver