### PR TITLE
replace sphinx-build for 18.04 compatibility

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
+SPHINXBUILD   ?= python3 -m sphinx.cmd.build
 SOURCEDIR     = source
 BUILDDIR      = build
 

--- a/makefile
+++ b/makefile
@@ -56,7 +56,7 @@ doc:
 	make -C docs html
 
 docclean:
-	make -C docs clean
+	rm -rf docs/build/*
 
 # Generate and serve local html documentation
 docserve: doc


### PR DESCRIPTION
On Ubuntu 18.04, sphinx-build is missing after
installing sphinx, so we use

python3 -m sphinx.cmd.build